### PR TITLE
:bug: fix: when create table srid set to 4326

### DIFF
--- a/backend/streetdrop-domain/src/main/java/com/depromeet/area/village/VillageArea.java
+++ b/backend/streetdrop-domain/src/main/java/com/depromeet/area/village/VillageArea.java
@@ -28,7 +28,7 @@ public class VillageArea {
     @Column(nullable = false)
     private int version;
 
-    @Column(nullable = false, columnDefinition = "MultiPolygon")
+    @Column(nullable = false, columnDefinition = "MULTIPOLYGON SRID 4326")
     private MultiPolygon villagePolygon;
 
     @Column(columnDefinition = "Point")


### PR DESCRIPTION
Resolve : https://github.com/depromeet/street-drop-server/issues/156
디비도 마이그레이션 완료했습니다.

MySQL에서는 테이블을 생성할 때 SRID를 명시적으로 정의하지 않으면 해당 칼럼은 모든 SRID를 저장할 수 있습니다.
하지만 하나의 칼럼에 저장된 데이터의 SRID가 제각각이라면 MySQL 서버는 인덱스를 사용할 수 없습니다.

**Before**
![238197999-8ed4ca4b-2519-471a-9c24-46f180f11917](https://github.com/depromeet/street-drop-server/assets/80201773/8558f2b9-abcc-457a-a96d-787e6a1d1ee1)

**After**
<img width="1214" alt="screenshot 2023-06-29 오후 5 01 32" src="https://github.com/depromeet/street-drop-server/assets/80201773/20cdddf5-25ee-4299-b953-5eea83550844">



_Refrence_
- https://dba.stackexchange.com/questions/260757/mysql-8-not-using
- Real MySQL 8.0, 백은빈, 이성욱 지음