### PR TITLE
:sparkles: feat(api): add error filter for test error case

### DIFF
--- a/backend/streetdrop-api/src/main/java/com/depromeet/common/error/dto/ErrorCodeMapper.java
+++ b/backend/streetdrop-api/src/main/java/com/depromeet/common/error/dto/ErrorCodeMapper.java
@@ -1,0 +1,14 @@
+package com.depromeet.common.error.dto;
+
+import java.util.Optional;
+
+public class ErrorCodeMapper {
+    public static Optional<ErrorCode> findByErrorCode(String code) {
+        for (ErrorCode errorCode : ErrorCode.values()) {
+            if (errorCode.getCode().equals(code)) {
+                return Optional.of(errorCode);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/backend/streetdrop-api/src/main/java/com/depromeet/test/error/filter/ErrorTestHeaderFilter.java
+++ b/backend/streetdrop-api/src/main/java/com/depromeet/test/error/filter/ErrorTestHeaderFilter.java
@@ -1,0 +1,57 @@
+package com.depromeet.test.error.filter;
+
+import com.depromeet.common.error.dto.ErrorCode;
+import com.depromeet.common.error.dto.ErrorCodeMapper;
+import com.depromeet.common.error.dto.ErrorResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.constraints.NotNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@Profile({"test", "local"})
+@Component
+@Slf4j
+public class ErrorTestHeaderFilter extends OncePerRequestFilter {
+
+    public static final String ERROR_TEST_HEADER = "STREET-DROP-ERROR-TEST-CODE";
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule()).disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, @NotNull HttpServletResponse response, @NotNull FilterChain filterChain) throws ServletException, IOException {
+        String errorTestHeader = request.getHeader(ERROR_TEST_HEADER);
+
+        if (errorTestHeader != null) {
+            Optional<ErrorCode> errorCode = ErrorCodeMapper.findByErrorCode(errorTestHeader);
+
+            if (errorCode.isPresent()) {
+                throwErrorResponse(response, errorCode.get());
+                return;
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private void throwErrorResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setContentType(APPLICATION_JSON_VALUE);
+        response.setStatus(errorCode.getStatus().value());
+
+        ErrorResponseDto errorResponseDto = new ErrorResponseDto(errorCode);
+        String errorResponseJson = objectMapper.writeValueAsString(errorResponseDto);
+
+        response.getWriter().write(errorResponseJson);
+    }
+
+}

--- a/backend/streetdrop-api/src/main/java/com/depromeet/test/error/filter/ErrorTestHeaderFilter.java
+++ b/backend/streetdrop-api/src/main/java/com/depromeet/test/error/filter/ErrorTestHeaderFilter.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-@Profile({"test", "local"})
+@Profile({"dev", "local"})
 @Component
 @Slf4j
 public class ErrorTestHeaderFilter extends OncePerRequestFilter {


### PR DESCRIPTION
- Resolve : https://github.com/depromeet/street-drop-server/issues/315
- Set to throw an error depending on the value of the header - only for test and local
- Existing value response if an invalid error header comes in

<img width="885" alt="screenshot 2023-08-26 오후 10 27 14" src="https://github.com/depromeet/street-drop-server/assets/80201773/3285cb2a-886d-4179-9cd7-be564ce9b81b">
