### PR TITLE
:sparkles: feat: add exception handling to notification server

### DIFF
--- a/backend/streetdrop-notification/src/main/java/com/depromeet/error/ErrorCode.java
+++ b/backend/streetdrop-notification/src/main/java/com/depromeet/error/ErrorCode.java
@@ -1,0 +1,22 @@
+package com.depromeet.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ErrorCode implements ErrorCodeInterface {
+    private HttpStatus status;
+    private ErrorDomain domainCode;
+    private String code;
+    private String title;
+    private String message;
+
+    @Override
+    public ErrorCode toErrorCode() {
+        return this;
+    }
+}

--- a/backend/streetdrop-notification/src/main/java/com/depromeet/error/ErrorCodeInterface.java
+++ b/backend/streetdrop-notification/src/main/java/com/depromeet/error/ErrorCodeInterface.java
@@ -1,0 +1,56 @@
+package com.depromeet.error;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * This interface provides a basic specification for defining domain error codes.
+ *
+ *
+ * This interface used to extend errorCodeEnum.
+ */
+public interface ErrorCodeInterface {
+
+    /**
+     * Returns the HTTP status code.
+     *
+     * @return The HTTP status code.
+     */
+    HttpStatus getStatus();
+
+
+    /**
+     * Returns the error code. It is not duplicated by domain at all.
+     *
+     * @return The error code.
+     */
+    String getCode();
+
+    /**
+     * Returns the error domain code. All errors are categorized by domain, so check the ErrorDomain code to see them.
+     *
+     * @return The domain code.
+     */
+    ErrorDomain getDomainCode();
+
+    /**
+     * Returns the error title - Short Human Readable Error Title.
+     *
+     * @return The error title.
+     */
+    String getTitle();
+
+    /**
+     * Returns the error message - Human Readable Error Message, It is also recommended that you write solutions together.
+     *
+     * @return The error message.
+     */
+    String getMessage();
+
+    /**
+     * Converts this to an ErrorCode object.
+     *
+     * @return An ErrorCode object.
+     */
+    ErrorCode toErrorCode();
+
+}

--- a/backend/streetdrop-notification/src/main/java/com/depromeet/error/ErrorDomain.java
+++ b/backend/streetdrop-notification/src/main/java/com/depromeet/error/ErrorDomain.java
@@ -1,0 +1,5 @@
+package com.depromeet.error;
+
+public enum ErrorDomain {
+    COMMON, AUTH, FIREBASE
+}

--- a/backend/streetdrop-notification/src/main/java/com/depromeet/error/ErrorResponse.java
+++ b/backend/streetdrop-notification/src/main/java/com/depromeet/error/ErrorResponse.java
@@ -1,0 +1,30 @@
+package com.depromeet.error;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ErrorResponse {
+    private final LocalDateTime timestamp = LocalDateTime.now();
+    private final int status;
+    private final ErrorDomain errorDomain;
+    private final String code;
+    private final String title;
+    private final String message;
+
+    public static <T extends ErrorCodeInterface> ResponseEntity<ErrorResponse> toResponseEntity(T errorCode) {
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.builder()
+                        .status(errorCode.getStatus().value())
+                        .errorDomain(errorCode.getDomainCode())
+                        .code(errorCode.getCode())
+                        .title(errorCode.getTitle())
+                        .message(errorCode.getMessage())
+                        .build());
+    }
+}

--- a/backend/streetdrop-notification/src/main/java/com/depromeet/error/GlobalExceptionHandler.java
+++ b/backend/streetdrop-notification/src/main/java/com/depromeet/error/GlobalExceptionHandler.java
@@ -1,0 +1,39 @@
+package com.depromeet.error;
+
+
+import com.depromeet.error.exceptions.BusinessException;
+import com.depromeet.error.code.GlobalErrorCode;
+import com.depromeet.error.exceptions.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.HttpClientErrorException;
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        return ErrorResponse.toResponseEntity(e.getErrorCode());
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
+        return ErrorResponse.toResponseEntity(e.getErrorCode());
+    }
+
+
+    @ExceptionHandler(HttpClientErrorException.BadRequest.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    protected ResponseEntity<ErrorResponse> handleBadRequestException(HttpClientErrorException.BadRequest e) {
+        return ErrorResponse.toResponseEntity(GlobalErrorCode.BAD_REQUEST);
+    }
+
+
+}

--- a/backend/streetdrop-notification/src/main/java/com/depromeet/error/code/FireBaseErrorCode.java
+++ b/backend/streetdrop-notification/src/main/java/com/depromeet/error/code/FireBaseErrorCode.java
@@ -1,0 +1,33 @@
+package com.depromeet.error.code;
+
+import com.depromeet.error.ErrorCode;
+import com.depromeet.error.ErrorCodeInterface;
+import com.depromeet.error.ErrorDomain;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum FireBaseErrorCode implements ErrorCodeInterface {
+
+    FIRE_BASE_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FireBase Internal Server Error", "FireBase Internal Server Error"),
+    TOO_MUCH_REQUEST(HttpStatus.TOO_MANY_REQUESTS, "Too Much Request to FireBase Server", "Too Much Request to FireBase Server, Request After 3 Minutes")
+    ;
+
+    private final HttpStatus status;
+    private final ErrorDomain domainCode = ErrorDomain.FIREBASE;
+    private final String code = name().toUpperCase();
+    private final String title;
+    private final String message;
+
+    public ErrorCode toErrorCode() {
+        return ErrorCode
+                .builder()
+                .status(status)
+                .domainCode(domainCode)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/backend/streetdrop-notification/src/main/java/com/depromeet/error/code/GlobalErrorCode.java
+++ b/backend/streetdrop-notification/src/main/java/com/depromeet/error/code/GlobalErrorCode.java
@@ -1,0 +1,33 @@
+package com.depromeet.error.code;
+
+import com.depromeet.error.ErrorCode;
+import com.depromeet.error.ErrorCodeInterface;
+import com.depromeet.error.ErrorDomain;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum GlobalErrorCode implements ErrorCodeInterface {
+
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "Bad Request", "This Request BadRequest"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error", "Internal Server Error"),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "Invalid Input Value", "Invalid Input Value"),
+    EXTERNAL_SERVER_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "External Sever Error","Invalid Input Value");
+
+    private final HttpStatus status;
+    private final String code = name().toUpperCase();
+    private final ErrorDomain domainCode = ErrorDomain.COMMON;
+    private final String title;
+    private final String message;
+
+    public ErrorCode toErrorCode() {
+        return ErrorCode.builder()
+                .status(status)
+                .domainCode(domainCode)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/backend/streetdrop-notification/src/main/java/com/depromeet/error/code/TokenErrorCode.java
+++ b/backend/streetdrop-notification/src/main/java/com/depromeet/error/code/TokenErrorCode.java
@@ -1,0 +1,32 @@
+package com.depromeet.error.code;
+
+import com.depromeet.error.ErrorCode;
+import com.depromeet.error.ErrorCodeInterface;
+import com.depromeet.error.ErrorDomain;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum TokenErrorCode implements ErrorCodeInterface {
+
+    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "Token is not found", "Token is not found"),
+    ;
+
+    private final HttpStatus status;
+    private final ErrorDomain domainCode = ErrorDomain.FIREBASE;
+    private final String code = name().toUpperCase();
+    private final String title;
+    private final String message;
+
+    public ErrorCode toErrorCode() {
+        return ErrorCode
+                .builder()
+                .status(status)
+                .domainCode(domainCode)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/backend/streetdrop-notification/src/main/java/com/depromeet/error/exceptions/BusinessException.java
+++ b/backend/streetdrop-notification/src/main/java/com/depromeet/error/exceptions/BusinessException.java
@@ -1,0 +1,19 @@
+package com.depromeet.error.exceptions;
+
+
+import com.depromeet.error.ErrorCode;
+import com.depromeet.error.ErrorCodeInterface;
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+    private final Exception exception;
+
+    public <T extends ErrorCodeInterface> BusinessException(T errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.toErrorCode();
+        this.exception = getException();
+    }
+
+}

--- a/backend/streetdrop-notification/src/main/java/com/depromeet/error/exceptions/ExternalServerException.java
+++ b/backend/streetdrop-notification/src/main/java/com/depromeet/error/exceptions/ExternalServerException.java
@@ -1,0 +1,17 @@
+package com.depromeet.error.exceptions;
+
+import com.depromeet.error.ErrorCode;
+import com.depromeet.error.ErrorCodeInterface;
+import lombok.Getter;
+
+@Getter
+public class ExternalServerException extends RuntimeException {
+    private final ErrorCode errorCode;
+    private final Exception exception;
+
+    public <T extends ErrorCodeInterface> ExternalServerException(T errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.toErrorCode();
+        this.exception = getException();
+    }
+}

--- a/backend/streetdrop-notification/src/main/java/com/depromeet/error/exceptions/NotFoundException.java
+++ b/backend/streetdrop-notification/src/main/java/com/depromeet/error/exceptions/NotFoundException.java
@@ -1,0 +1,17 @@
+package com.depromeet.error.exceptions;
+
+import com.depromeet.error.ErrorCode;
+import com.depromeet.error.ErrorCodeInterface;
+import lombok.Getter;
+
+@Getter
+public class NotFoundException extends RuntimeException {
+    private final ErrorCode errorCode;
+    private final Exception exception;
+
+    public <T extends ErrorCodeInterface> NotFoundException(T errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.toErrorCode();
+        this.exception = getException();
+    }
+}

--- a/backend/streetdrop-notification/src/main/java/com/depromeet/external/fcm/FcmConfig.java
+++ b/backend/streetdrop-notification/src/main/java/com/depromeet/external/fcm/FcmConfig.java
@@ -1,5 +1,7 @@
 package com.depromeet.external.fcm;
 
+import com.depromeet.error.exceptions.BusinessException;
+import com.depromeet.error.code.GlobalErrorCode;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
@@ -29,8 +31,7 @@ public class FcmConfig {
                 FirebaseApp.initializeApp(options);
             }
         } catch (IOException e) {
-            e.printStackTrace();
-            throw new RuntimeException("Firebase initialization failed");
+            throw new BusinessException(GlobalErrorCode.BAD_REQUEST);
         }
     }
 }

--- a/backend/streetdrop-notification/src/main/java/com/depromeet/service/PushService.java
+++ b/backend/streetdrop-notification/src/main/java/com/depromeet/service/PushService.java
@@ -4,8 +4,12 @@ import com.depromeet.domain.UserDevice;
 import com.depromeet.dto.request.AllPushRequestDto;
 import com.depromeet.dto.request.PushRequestDto;
 import com.depromeet.dto.request.TopicPushRequestDto;
+import com.depromeet.error.ErrorCode;
+import com.depromeet.error.code.FireBaseErrorCode;
+import com.depromeet.error.exceptions.ExternalServerException;
 import com.depromeet.external.fcm.FcmService;
 import com.depromeet.repository.UserDeviceRepository;
+import com.google.firebase.FirebaseException;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -40,6 +44,7 @@ public class PushService {
                 }
             }
         } catch (FirebaseMessagingException e) {
+            throw new ExternalServerException(FireBaseErrorCode.FIRE_BASE_INTERNAL_SERVER_ERROR);
         }
 
         notificationService.save(pushRequestDto);
@@ -58,6 +63,7 @@ public class PushService {
                 fcmService.sendMulticastMessageSync(tokens, pushRequestDto.getContent());
             }
         } catch (FirebaseMessagingException e) {
+            throw new ExternalServerException(FireBaseErrorCode.FIRE_BASE_INTERNAL_SERVER_ERROR);
         }
 
         notificationService.save(pushRequestDto);
@@ -72,6 +78,7 @@ public class PushService {
                 fcmService.sendTopicMessageSync(tokenPushRequestDto.getTopic(), tokenPushRequestDto.getContent());
             }
         } catch (FirebaseMessagingException e) {
+            throw new ExternalServerException(FireBaseErrorCode.FIRE_BASE_INTERNAL_SERVER_ERROR);
         }
 
         notificationService.save(tokenPushRequestDto);

--- a/backend/streetdrop-notification/src/main/java/com/depromeet/service/TokenService.java
+++ b/backend/streetdrop-notification/src/main/java/com/depromeet/service/TokenService.java
@@ -2,6 +2,9 @@ package com.depromeet.service;
 
 import com.depromeet.domain.UserDevice;
 import com.depromeet.dto.request.TokenRequestDto;
+import com.depromeet.error.code.TokenErrorCode;
+import com.depromeet.error.exceptions.BusinessException;
+import com.depromeet.error.exceptions.NotFoundException;
 import com.depromeet.repository.UserDeviceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -33,7 +36,7 @@ public class TokenService {
     @Transactional
     public void deleteToken(Long userId) {
         var userDevice = userDeviceRepository.findByUserId(userId)
-                .orElseThrow(() -> new RuntimeException("Token not found for userId: " + userId));
+                .orElseThrow(() -> new NotFoundException(TokenErrorCode.TOKEN_NOT_FOUND));
         userDeviceRepository.delete(userDevice);
     }
 }

--- a/backend/streetdrop-notification/src/main/java/com/depromeet/service/TopicService.java
+++ b/backend/streetdrop-notification/src/main/java/com/depromeet/service/TopicService.java
@@ -2,8 +2,13 @@ package com.depromeet.service;
 
 import com.depromeet.domain.UserDevice;
 import com.depromeet.dto.request.TopicSubscribeRequestDto;
+import com.depromeet.error.code.FireBaseErrorCode;
+import com.depromeet.error.code.TokenErrorCode;
+import com.depromeet.error.exceptions.ExternalServerException;
+import com.depromeet.error.exceptions.NotFoundException;
 import com.depromeet.external.fcm.FcmService;
 import com.depromeet.repository.UserDeviceRepository;
+import com.google.firebase.messaging.FirebaseMessagingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,7 +25,8 @@ public class TopicService {
         List<String> tokens = getTokens(topicSubscribeRequestDto.getUserIds());
         try {
             fcmService.subscribeTopicSync(topicSubscribeRequestDto.getTopic(), tokens);
-        } catch (Exception e) {
+        } catch (FirebaseMessagingException e) {
+            throw new ExternalServerException(FireBaseErrorCode.FIRE_BASE_INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -28,14 +34,15 @@ public class TopicService {
         List<String> tokens = getTokens(topicSubscribeRequestDto.getUserIds());
         try {
             fcmService.subscribeTopicSync(topicSubscribeRequestDto.getTopic(), tokens);
-        } catch (Exception e) {
+        } catch (FirebaseMessagingException e) {
+            throw new ExternalServerException(FireBaseErrorCode.FIRE_BASE_INTERNAL_SERVER_ERROR);
         }
     }
 
     private List<String> getTokens(List<Long> userIds) {
         return userIds.stream()
                 .map(userId -> userDeviceRepository.findByUserId(userId)
-                        .orElseThrow(() -> new RuntimeException("Token not found for userId: " + userId)))
+                        .orElseThrow(() -> new NotFoundException(TokenErrorCode.TOKEN_NOT_FOUND)))
                 .map(UserDevice::getDeviceToken)
                 .toList();
     }


### PR DESCRIPTION
- Resolve: https://github.com/depromeet/street-drop-server/issues/192
- Reference : https://github.com/depromeet/street-drop-server/issues/137
- 인터페이스를 통해 Enum을 확장했습니다.
- 제너릭을 활용하여 특정 인터페이스를 구현한 enum만 처리하게끔 하였습니다.
``` java
    public <T extends ErrorCodeInterface> ExternalServerException(T errorCode) {
        super(errorCode.getMessage());
        this.errorCode = errorCode.toErrorCode();
        this.exception = getException();
    }
```
- ErrorDomain Enum을 만들어서, 에러 발생 도메인을 제한하였습니다.
- Haman Readable 할 수 있는 message 외에도 title을 추가하여, 에러 내용은 title에, 상세내용과 해결방법에 대해서는 message에 작성할 수 있도록 하였습니다.
- **_API 서버의 경우 여기서 논의된 에러 처리방법에 따라 변경할 예정입니다._**