### PR TITLE
:bug: fix(api): AppleMusicConfig import failed

### DIFF
--- a/backend/streetdrop-api/src/main/java/com/depromeet/domains/search/service/AppleMusicSearchService.java
+++ b/backend/streetdrop-api/src/main/java/com/depromeet/domains/search/service/AppleMusicSearchService.java
@@ -1,9 +1,8 @@
 package com.depromeet.domains.search.service;
 
-
-import com.depromeet.domains.search.config.AppleMusicConfig;
 import com.depromeet.domains.search.response.MusicInfoListResponseDto;
 import com.depromeet.domains.search.response.apple.AppleMusicResponseDto;
+import com.depromeet.external.applemusic.config.AppleMusicConfig;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpHeaders;


### PR DESCRIPTION
#505 의 [댓글](https://github.com/depromeet/street-drop-server/pull/505#discussion_r1740651699) 에서 AppleMusicConfig 위치를 변경했습니다.
AppleMusicConfig을 사용하는 AppleMusicSearchService 쪽도 변경해주지 않아 import에서 오류가 발생하는 문제를 해결했습니다